### PR TITLE
feat: use p6spy's log filtering settings when tracing

### DIFF
--- a/instrumentation/p6spy/README.md
+++ b/instrumentation/p6spy/README.md
@@ -42,3 +42,11 @@ jdbc:mysql://127.0.0.1:3306/mydatabase?zipkinServiceName=myServiceName
 This will override the `remoteServiceName` set in `spy.properties`.
 
 The current tracing component is used at runtime. Until you have instantiated `brave.Tracing`, no traces will appear.
+
+### Filtering spans
+
+By default, all statements are recorded as client spans. 
+You may wish to exclude statements like `set session` from tracing. This library reuses p6spy's log filtering for this purpose.
+Filtering options are picked up from `spy.properties`, so you can blacklist/whitelist what type of statements to record as spans.
+
+For configuration details please see p6spy's log filtering documentation.

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6Factory.java
@@ -28,6 +28,7 @@ public final class TracingP6Factory implements P6Factory {
   }
 
   @Override public JdbcEventListener getJdbcEventListener() {
-    return new TracingJdbcEventListener(options.remoteServiceName(), options.includeParameterValues());
+    return new TracingJdbcEventListener(options.remoteServiceName(),
+        options.includeParameterValues(), options.getLogOptions());
   }
 }

--- a/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
+++ b/instrumentation/p6spy/src/main/java/brave/p6spy/TracingP6SpyOptions.java
@@ -13,25 +13,47 @@
  */
 package brave.p6spy;
 
+import com.p6spy.engine.logging.P6LogLoadableOptions;
+import com.p6spy.engine.logging.P6LogOptions;
 import com.p6spy.engine.spy.P6SpyOptions;
 import com.p6spy.engine.spy.option.P6OptionsRepository;
+
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 final class TracingP6SpyOptions extends P6SpyOptions {
+
   static final String REMOTE_SERVICE_NAME = "remoteServiceName";
   static final String INCLUDE_PARAMETER_VALUES = "includeParameterValues";
 
-  final P6OptionsRepository optionsRepository;
+  private final P6OptionsRepository optionsRepository;
+  private final P6LogLoadableOptions logLoadableOptions;
 
   TracingP6SpyOptions(P6OptionsRepository optionsRepository) {
     super(optionsRepository);
+    logLoadableOptions = new P6LogOptions(optionsRepository);
     this.optionsRepository = optionsRepository;
   }
 
-  @Override public void load(Map<String, String> options) {
+  @Override
+  public void load(Map<String, String> options) {
     super.load(options);
+    logLoadableOptions.load(options);
     optionsRepository.set(String.class, REMOTE_SERVICE_NAME, options.get(REMOTE_SERVICE_NAME));
-    optionsRepository.set(Boolean.class, INCLUDE_PARAMETER_VALUES, options.get(INCLUDE_PARAMETER_VALUES));
+    optionsRepository.set(Boolean.class, INCLUDE_PARAMETER_VALUES,
+        options.get(INCLUDE_PARAMETER_VALUES));
+  }
+
+  @Override
+  public Map<String, String> getDefaults() {
+    Map<String, String> allDefaults = new LinkedHashMap(super.getDefaults());
+    allDefaults.putAll(logLoadableOptions.getDefaults());
+    allDefaults.put(INCLUDE_PARAMETER_VALUES, Boolean.FALSE.toString());
+    return allDefaults;
+  }
+
+  P6LogLoadableOptions getLogOptions() {
+    return logLoadableOptions;
   }
 
   String remoteServiceName() {
@@ -39,7 +61,6 @@ final class TracingP6SpyOptions extends P6SpyOptions {
   }
 
   Boolean includeParameterValues() {
-    Boolean logParameterValues = optionsRepository.get(Boolean.class, INCLUDE_PARAMETER_VALUES);
-    return logParameterValues == null ? false : logParameterValues;
+    return optionsRepository.get(Boolean.class, INCLUDE_PARAMETER_VALUES);
   }
 }


### PR DESCRIPTION
p6spy provides sql query filtering options which were not used during span
creation, added support for them.

p6spy tends to produce enormous amount of logs due to including all queries, sending this huge amount of spans is usually counterproductive ,adds noise to the analysis and increases costs