### PR TITLE
Remove intermediate buffer in ASCII string read.

### DIFF
--- a/instrumentation/grpc/src/main/java/brave/grpc/TagContextBinaryMarshaller.java
+++ b/instrumentation/grpc/src/main/java/brave/grpc/TagContextBinaryMarshaller.java
@@ -2,6 +2,7 @@ package brave.grpc;
 
 import brave.internal.Platform;
 import io.grpc.Metadata.BinaryMarshaller;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -15,6 +16,8 @@ import java.util.Map;
 final class TagContextBinaryMarshaller implements BinaryMarshaller<Map<String, String>> {
   static final byte VERSION = 0, TAG_FIELD_ID = 0;
   static final byte[] EMPTY_BYTES = {};
+
+  static final Charset US_ASCII = Charset.forName("US-ASCII");
 
   @Override
   public byte[] toBytes(Map<String, String> tagContext) {
@@ -137,11 +140,10 @@ final class TagContextBinaryMarshaller implements BinaryMarshaller<Map<String, S
 
     String readAsciiString(int length) {
       if (length == -1 || remaining() < length) return null;
-      char[] string = new char[length];
-      for (int i = 0; i < length; i++) {
-        string[i] = (char) buf[pos++];
-      }
-      return new String(string);
+
+      String result = new String(buf, pos, length, US_ASCII);
+      pos += length;
+      return result;
     }
   }
 }


### PR DESCRIPTION
For #905 

Fruit doesn't get much lower than this.

After
```
Benchmark                                                                                          Mode     Cnt     Score     Error   Units
TagContextBinaryMarshallerBenchmarks.parseBytes                                                  sample  342147     0.139 ±   0.015   us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.00                                 sample               ≈ 0             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.50                                 sample             0.100             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.90                                 sample             0.100             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.95                                 sample             0.200             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.99                                 sample             0.200             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.999                                sample            13.088             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.9999                               sample            24.711             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p1.00                                 sample          1134.592             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.alloc.rate                                   sample      15  2246.556 ±  33.938  MB/sec
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.alloc.rate.norm                              sample      15   304.017 ±  12.522    B/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.CodeHeap_'non-profiled_nmethods'       sample      15     0.006 ±   0.002  MB/sec
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.CodeHeap_'non-profiled_nmethods'.norm  sample      15     0.001 ±   0.001    B/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.G1_Old_Gen                             sample      15  2267.813 ± 100.674  MB/sec
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.G1_Old_Gen.norm                        sample      15   306.881 ±  17.460    B/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.count                                        sample      15   158.000            counts
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.time                                         sample      15   122.000                ms
```

Before
```
Benchmark                                                                                          Mode     Cnt     Score     Error   Units
TagContextBinaryMarshallerBenchmarks.parseBytes                                                  sample  356049     0.149 ±   0.049   us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.00                                 sample               ≈ 0             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.50                                 sample             0.100             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.90                                 sample             0.100             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.95                                 sample             0.200             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.99                                 sample             0.201             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.999                                sample             8.283             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p0.9999                               sample            21.888             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:parseBytes·p1.00                                 sample          4825.088             us/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.alloc.rate                                   sample      15  3079.843 ± 155.576  MB/sec
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.alloc.rate.norm                              sample      15   400.017 ±   0.002    B/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.CodeHeap_'non-profiled_nmethods'       sample      15     0.005 ±   0.002  MB/sec
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.CodeHeap_'non-profiled_nmethods'.norm  sample      15     0.001 ±   0.001    B/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.G1_Old_Gen                             sample      15  3089.305 ± 243.503  MB/sec
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.churn.G1_Old_Gen.norm                        sample      15   400.928 ±  17.701    B/op
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.count                                        sample      15   202.000            counts
TagContextBinaryMarshallerBenchmarks.parseBytes:·gc.time                                         sample      15   154.000                ms
```