### PR TITLE
Fixes some edge cases around sampler resetting

### DIFF
--- a/brave/src/main/java/brave/sampler/RateLimitingSampler.java
+++ b/brave/src/main/java/brave/sampler/RateLimitingSampler.java
@@ -132,8 +132,9 @@ public class RateLimitingSampler extends Sampler {
     }
 
     @Override int max(long nanosUntilReset) {
-      // Check to see if we are in the first interval
+      // Check to see if we are in the first or last interval
       if (nanosUntilReset > NANOS_PER_SECOND - NANOS_PER_DECISECOND) return max[0];
+      if (nanosUntilReset < NANOS_PER_DECISECOND) return max[9];
 
       // Choose a slot based on the remaining deciseconds
       int decisecondsUntilReset = (int) (nanosUntilReset / NANOS_PER_DECISECOND);

--- a/brave/src/main/java/brave/sampler/RateLimitingSampler.java
+++ b/brave/src/main/java/brave/sampler/RateLimitingSampler.java
@@ -92,7 +92,6 @@ public class RateLimitingSampler extends Sampler {
   }
 
   static abstract class MaxFunction {
-    /** @param nanosUntilReset zero if was just reset */
     abstract int max(long nanosUntilReset);
   }
 
@@ -104,7 +103,7 @@ public class RateLimitingSampler extends Sampler {
       this.tracesPerSecond = tracesPerSecond;
     }
 
-    @Override int max(long nanosUntilReset) {
+    @Override int max(long nanosUntilResetIgnored) {
       return tracesPerSecond;
     }
   }
@@ -133,9 +132,9 @@ public class RateLimitingSampler extends Sampler {
     }
 
     @Override int max(long nanosUntilReset) {
+      assert nanosUntilReset != 0; // recursion ensures this is never zero
       int decisecondsUntilReset = ((int) nanosUntilReset / NANOS_PER_DECISECOND);
-      int index = decisecondsUntilReset == 0 ? 0 : 10 - decisecondsUntilReset;
-      return max[index];
+      return max[10 - decisecondsUntilReset];
     }
   }
 }

--- a/brave/src/main/java/brave/sampler/RateLimitingSampler.java
+++ b/brave/src/main/java/brave/sampler/RateLimitingSampler.java
@@ -53,7 +53,7 @@ public class RateLimitingSampler extends Sampler {
   }
 
   static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
-  static final int NANOS_PER_DECISECOND = (int) (NANOS_PER_SECOND / 10);
+  static final long NANOS_PER_DECISECOND = NANOS_PER_SECOND / 10;
 
   final MaxFunction maxFunction;
   final AtomicInteger usage = new AtomicInteger(0);
@@ -132,8 +132,11 @@ public class RateLimitingSampler extends Sampler {
     }
 
     @Override int max(long nanosUntilReset) {
-      assert nanosUntilReset != 0; // recursion ensures this is never zero
-      int decisecondsUntilReset = ((int) nanosUntilReset / NANOS_PER_DECISECOND);
+      // Check to see if we are in the first interval
+      if (nanosUntilReset > NANOS_PER_SECOND - NANOS_PER_DECISECOND) return max[0];
+
+      // Choose a slot based on the remaining deciseconds
+      int decisecondsUntilReset = (int) (nanosUntilReset / NANOS_PER_DECISECOND);
       return max[10 - decisecondsUntilReset];
     }
   }

--- a/brave/src/main/java/brave/sampler/RateLimitingSampler.java
+++ b/brave/src/main/java/brave/sampler/RateLimitingSampler.java
@@ -61,7 +61,7 @@ public class RateLimitingSampler extends Sampler {
 
   RateLimitingSampler(int tracesPerSecond) {
     this.maxFunction =
-        tracesPerSecond < 10 ? new LessThan10(tracesPerSecond) : new AtLeast10(tracesPerSecond);
+      tracesPerSecond < 10 ? new LessThan10(tracesPerSecond) : new AtLeast10(tracesPerSecond);
     long now = System.nanoTime();
     this.nextReset = new AtomicLong(now + NANOS_PER_SECOND);
   }
@@ -74,7 +74,7 @@ public class RateLimitingSampler extends Sampler {
     if (nanosUntilReset <= 0) {
       // Attempt to move into the next sampling interval.
       // nanosUntilReset is now invalid regardless of race winner, so we can't sample based on it.
-      if (nextReset.compareAndSet(updateAt, updateAt + NANOS_PER_SECOND)) usage.set(0);
+      if (nextReset.compareAndSet(updateAt, now + NANOS_PER_SECOND)) usage.set(0);
 
       // recurse as it is simpler than resetting all the locals.
       // reset happens once per second, this code doesn't take a second, so no infinite recursion.

--- a/brave/src/main/java/brave/sampler/RateLimitingSampler.java
+++ b/brave/src/main/java/brave/sampler/RateLimitingSampler.java
@@ -71,14 +71,17 @@ public class RateLimitingSampler extends Sampler {
     long updateAt = nextReset.get();
 
     long nanosUntilReset = -(now - updateAt); // because nanoTime can be negative
-    boolean shouldReset = nanosUntilReset <= 0;
-    if (shouldReset) {
-      if (nextReset.compareAndSet(updateAt, updateAt + NANOS_PER_SECOND)) {
-        usage.set(0);
-      }
+    if (nanosUntilReset <= 0) {
+      // Attempt to move into the next sampling interval.
+      // nanosUntilReset is now invalid regardless of race winner, so we can't sample based on it.
+      if (nextReset.compareAndSet(updateAt, updateAt + NANOS_PER_SECOND)) usage.set(0);
+
+      // recurse as it is simpler than resetting all the locals.
+      // reset happens once per second, this code doesn't take a second, so no infinite recursion.
+      return isSampled(ignoredTraceId);
     }
 
-    int max = maxFunction.max(shouldReset ? 0 : nanosUntilReset);
+    int max = maxFunction.max(nanosUntilReset);
     int prev, next;
     do { // same form as java 8 AtomicLong.getAndUpdate
       prev = usage.get();

--- a/brave/src/test/java/brave/sampler/RateLimitingSamplerTest.java
+++ b/brave/src/test/java/brave/sampler/RateLimitingSamplerTest.java
@@ -98,15 +98,27 @@ public class RateLimitingSamplerTest {
     Sampler sampler = RateLimitingSampler.create(10);
 
     // try exact same nanosecond, however unlikely
-    assertThat(sampler.isSampled(0L)).isTrue();
+    assertThat(sampler.isSampled(0L)).isTrue(); // 1
 
     // Try a value smaller than a decisecond, to ensure edge cases are covered
     when(System.nanoTime()).thenReturn(1L);
-    assertThat(sampler.isSampled(0L)).isFalse();
+    assertThat(sampler.isSampled(0L)).isFalse(); // credit used
 
     // Try exactly a decisecond later, which should be a reset condition
     when(System.nanoTime()).thenReturn(NANOS_PER_DECISECOND);
-    assertThat(sampler.isSampled(0L)).isTrue();
+    assertThat(sampler.isSampled(0L)).isTrue(); // 2
+    assertThat(sampler.isSampled(0L)).isFalse(); // credit used
+
+    // Try almost a second later
+    when(System.nanoTime()).thenReturn(NANOS_PER_SECOND - 1);
+    assertThat(sampler.isSampled(0L)).isTrue(); // 3
+    assertThat(sampler.isSampled(0L)).isTrue(); // 4
+    assertThat(sampler.isSampled(0L)).isTrue(); // 5
+    assertThat(sampler.isSampled(0L)).isTrue(); // 6
+    assertThat(sampler.isSampled(0L)).isTrue(); // 7
+    assertThat(sampler.isSampled(0L)).isTrue(); // 8
+    assertThat(sampler.isSampled(0L)).isTrue(); // 9
+    assertThat(sampler.isSampled(0L)).isTrue(); // 10
     assertThat(sampler.isSampled(0L)).isFalse(); // credit used
 
     // Try exactly a second later, which should be a reset condition


### PR DESCRIPTION
I found these working on https://github.com/adriancole/zipkin-voltdb/pull/18

I don't have unit tests for the changes, but integrated looks a bit right now.

I think @pburm might be interested.