### PR TITLE
Add tests for #920. "brave.fush" annotation should not be reported for finished spans

### DIFF
--- a/brave/src/main/java/brave/internal/recorder/PendingSpans.java
+++ b/brave/src/main/java/brave/internal/recorder/PendingSpans.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public final class PendingSpans extends ReferenceQueue<TraceContext> {
   private static final Logger LOG = Logger.getLogger(PendingSpans.class.getName());
 
-  // Eventhough we only put by RealKey, we allow get and remove by LookupKey
+  // Even though we only put by RealKey, we allow get and remove by LookupKey
   final ConcurrentMap<Object, PendingSpan> delegate = new ConcurrentHashMap<>(64);
   final Clock clock;
   final FinishedSpanHandler zipkinHandler; // Used when flushing spans

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -34,8 +34,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Test;
+import zipkin2.Annotation;
 import zipkin2.Endpoint;
 import zipkin2.reporter.Reporter;
 
@@ -693,6 +695,53 @@ public class TracerTest {
         .isPositive();
   }
 
+  @Test public void useSpanAfterFinished_doesNotCauseBraveFlush() throws InterruptedException {
+    simulateInProcessPropagation(tracer, tracer);
+    blockOnGC();
+    tracer.newTrace().start().abandon(); //trigger orphaned span check
+    assertThat(spans).hasSize(1);
+    assertThat(spans.stream()
+      .flatMap(span -> span.annotations().stream())
+      .map(Annotation::value)
+      .collect(Collectors.toList())).doesNotContain("brave.flush");
+  }
+
+  @Test public void useSpanAfterFinishedInOtherTracer_doesNotCauseBraveFlush()
+    throws InterruptedException {
+    Tracer noOpTracer = Tracing.newBuilder()
+      .spanReporter(Reporter.NOOP)
+      .build().tracer();
+    simulateInProcessPropagation(noOpTracer, tracer);
+    blockOnGC();
+    tracer.newTrace().start().abandon(); //trigger orphaned span check
+
+    // We expect the span to be reported to the NOOP reporter, and nothing to be reported to "spans"
+    assertThat(spans).hasSize(0);
+    assertThat(spans.stream()
+      .flatMap(span -> span.annotations().stream())
+      .map(Annotation::value)
+      .collect(Collectors.toList())).doesNotContain("brave.flush");
+  }
+
+  /**
+   * Must be a separate method from the test method to allow for local variables to be garbage
+   * collected
+   */
+  private static void simulateInProcessPropagation(Tracer tracer1, Tracer tracer2) {
+    Span span1 = tracer1.newTrace();
+    span1.start();
+
+    // Pretend we're on child thread
+    Tracer.SpanInScope spanInScope = tracer2.withSpanInScope(span1);
+
+    // Back on original thread
+    span1.finish();
+
+    // Pretend we're on child thread
+    Span span2 = tracer2.currentSpan();
+    spanInScope.close();
+  }
+
   @Test public void localRootId_joinSpan_notYetSampled() {
     TraceContext context1 = TraceContext.newBuilder().traceId(1).spanId(2).build();
     TraceContext context2 = TraceContext.newBuilder().traceId(1).spanId(3).build();
@@ -825,5 +874,10 @@ public class TracerTest {
       }
     }).spanReporter(Reporter.NOOP).build().tracer();
     return reportedNames;
+  }
+
+  static void blockOnGC() throws InterruptedException {
+    System.gc();
+    Thread.sleep(200L);
   }
 }

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -709,7 +709,6 @@ public class TracerTest {
   @Test public void useSpanAfterFinishedInOtherTracer_doesNotCauseBraveFlush()
     throws InterruptedException {
     Tracer noOpTracer = Tracing.newBuilder()
-      .spanReporter(Reporter.NOOP)
       .build().tracer();
     simulateInProcessPropagation(noOpTracer, tracer);
     blockOnGC();


### PR DESCRIPTION
These tests are currently failing, but show same bug as described in #920. See issue for more details.