### PR TITLE
 Makes Tracer.currentSpanCustomizer() lazy 

### DIFF
--- a/brave/src/main/java/brave/LazySpan.java
+++ b/brave/src/main/java/brave/LazySpan.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package brave;
+
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+
+/**
+ * This defers creation of a span until first public method call.
+ *
+ * <p>This type was created to reduce overhead for code that calls {@link Tracer#currentSpan()},
+ * but without ever using the result.
+ */
+final class LazySpan extends Span {
+  final Tracer tracer;
+  final TraceContext context;
+  volatile Span delegate;
+
+  LazySpan(Tracer tracer, TraceContext context) {
+    this.tracer = tracer;
+    this.context = context;
+  }
+
+  @Override public boolean isNoop() {
+    return false;
+  }
+
+  @Override public TraceContext context() {
+    return context;
+  }
+
+  @Override public SpanCustomizer customizer() {
+    return new SpanCustomizerShield(this);
+  }
+
+  @Override public Span start() {
+    return span().start();
+  }
+
+  @Override public Span start(long timestamp) {
+    return span().start(timestamp);
+  }
+
+  @Override public Span name(String name) {
+    return span().name(name);
+  }
+
+  @Override public Span kind(Kind kind) {
+    return span().kind(kind);
+  }
+
+  @Override public Span annotate(String value) {
+    return span().annotate(value);
+  }
+
+  @Override public Span annotate(long timestamp, String value) {
+    return span().annotate(timestamp, value);
+  }
+
+  @Override public Span tag(String key, String value) {
+    return span().tag(key, value);
+  }
+
+  @Override public Span error(Throwable throwable) {
+    return span().error(throwable);
+  }
+
+  @Override public Span remoteServiceName(String remoteServiceName) {
+    return span().remoteServiceName(remoteServiceName);
+  }
+
+  @Override public boolean remoteIpAndPort(String remoteIp, int remotePort) {
+    return span().remoteIpAndPort(remoteIp, remotePort);
+  }
+
+  @Override public void finish() {
+    span().finish();
+  }
+
+  @Override public void finish(long timestamp) {
+    span().finish(timestamp);
+  }
+
+  @Override public void abandon() {
+    if (delegate == null) return; // prevent resurrection
+    span().abandon();
+  }
+
+  @Override public void flush() {
+    if (delegate == null) return; // prevent resurrection
+    span().flush();
+  }
+
+  @Override public String toString() {
+    return "LazySpan(" + context + ")";
+  }
+
+  /**
+   * This also matches equals against a real span. The rationale is least surprise to the user, as
+   * code should not act differently given an instance of lazy or {@link RealSpan}.
+   */
+  @Override public boolean equals(Object o) {
+    if (o == this) return true;
+    if (o instanceof LazySpan) {
+      return context.equals(((LazySpan) o).context);
+    } else if (o instanceof RealSpan) {
+      return context.equals(((RealSpan) o).context);
+    }
+    return false;
+  }
+
+  /**
+   * This does not guard on all concurrent edge cases assigning the delegate field. That's because
+   * this type is only used when a user calls {@link Tracer#currentSpan()}, which is unlikley to be
+   * exposed in such a way that multiple threads end up in a race assigning the field. Finally,
+   * there is no state risk if {@link Tracer#toSpan(TraceContext)} is called concurrently. Duplicate
+   * instances of span may occur, but they would share the same {@link MutableSpan} instance
+   * internally.
+   */
+  Span span() {
+    Span result = delegate;
+    if (result != null) return result;
+    return delegate = tracer.toSpan(context);
+  }
+
+  @Override public int hashCode() {
+    return context.hashCode();
+  }
+}

--- a/brave/src/main/java/brave/LazySpan.java
+++ b/brave/src/main/java/brave/LazySpan.java
@@ -28,7 +28,7 @@ import brave.propagation.TraceContext;
 final class LazySpan extends Span {
   final Tracer tracer;
   final TraceContext context;
-  volatile Span delegate;
+  Span delegate;
 
   LazySpan(Tracer tracer, TraceContext context) {
     this.tracer = tracer;

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -29,7 +29,6 @@ final class RealSpan extends Span {
   final MutableSpan state;
   final Clock clock;
   final FinishedSpanHandler finishedSpanHandler;
-  final RealSpanCustomizer customizer;
 
   RealSpan(TraceContext context,
       PendingSpans pendingSpans,
@@ -41,7 +40,6 @@ final class RealSpan extends Span {
     this.pendingSpans = pendingSpans;
     this.state = state;
     this.clock = clock;
-    this.customizer = new RealSpanCustomizer(context, state, clock);
     this.finishedSpanHandler = finishedSpanHandler;
   }
 
@@ -54,7 +52,7 @@ final class RealSpan extends Span {
   }
 
   @Override public SpanCustomizer customizer() {
-    return new RealSpanCustomizer(context, state, clock);
+    return new SpanCustomizerShield(this);
   }
 
   @Override public Span start() {

--- a/brave/src/main/java/brave/SpanCustomizerShield.java
+++ b/brave/src/main/java/brave/SpanCustomizerShield.java
@@ -16,46 +16,32 @@
  */
 package brave;
 
-import brave.handler.MutableSpan;
-import brave.propagation.TraceContext;
+/** This reduces exposure of methods on {@link Span} to those exposed on {@link SpanCustomizer}. */
+final class SpanCustomizerShield implements SpanCustomizer {
 
-/** This wraps the public api and guards access to a mutable span. */
-final class RealSpanCustomizer implements SpanCustomizer {
+  final Span delegate;
 
-  final TraceContext context;
-  final MutableSpan state;
-  final Clock clock;
-
-  RealSpanCustomizer(TraceContext context, MutableSpan state, Clock clock) {
-    this.context = context;
-    this.state = state;
-    this.clock = clock;
+  SpanCustomizerShield(Span delegate) {
+    this.delegate = delegate;
   }
 
   @Override public SpanCustomizer name(String name) {
-    synchronized (state) {
-      state.name(name);
-    }
+    delegate.name(name);
     return this;
   }
 
   @Override public SpanCustomizer annotate(String value) {
-    long timestamp = clock.currentTimeMicroseconds();
-    synchronized (state) {
-      state.annotate(timestamp, value);
-    }
+    delegate.annotate(value);
     return this;
   }
 
   @Override public SpanCustomizer tag(String key, String value) {
-    synchronized (state) {
-      state.tag(key, value);
-    }
+    delegate.tag(key, value);
     return this;
   }
 
   @Override
   public String toString() {
-    return "RealSpanCustomizer(" + context + ")";
+    return "SpanCustomizer(" + delegate.customizer() + ")";
   }
 }

--- a/brave/src/test/java/brave/RealSpanTest.java
+++ b/brave/src/test/java/brave/RealSpanTest.java
@@ -48,7 +48,7 @@ public class RealSpanTest {
   }
 
   @Test public void hasRealCustomizer() {
-    assertThat(span.customizer()).isInstanceOf(RealSpanCustomizer.class);
+    assertThat(span.customizer()).isInstanceOf(SpanCustomizerShield.class);
   }
 
   @Test public void start() {

--- a/brave/src/test/java/brave/TracerTest.java
+++ b/brave/src/test/java/brave/TracerTest.java
@@ -396,7 +396,7 @@ public class TracerTest {
 
     try {
       assertThat(tracer.currentSpanCustomizer())
-          .isInstanceOf(RealSpanCustomizer.class);
+          .isInstanceOf(SpanCustomizerShield.class);
     } finally {
       parent.finish();
     }

--- a/instrumentation/benchmarks/src/main/java/brave/TracerBenchmarks.java
+++ b/instrumentation/benchmarks/src/main/java/brave/TracerBenchmarks.java
@@ -19,6 +19,7 @@ package brave;
 import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.propagation.B3Propagation;
+import brave.propagation.CurrentTraceContext;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
 import brave.propagation.SamplingFlags;
@@ -223,6 +224,25 @@ public class TracerBenchmarks {
       span.tag("baz", "qux");
     } finally {
       span.finish();
+    }
+  }
+
+  @Benchmark public void currentSpan() {
+    currentSpan(tracer, extracted.context(), false);
+  }
+
+  @Benchmark public void currentSpan_tag() {
+    currentSpan(tracer, extracted.context(), true);
+  }
+
+  @Benchmark public void currentSpan_unsampled() {
+    currentSpan(tracer, unsampledExtracted.context(), false);
+  }
+
+  void currentSpan(Tracer tracer, TraceContext context, boolean tag) {
+    try (CurrentTraceContext.Scope scope = tracer.currentTraceContext.newScope(context)) {
+      Span span = tracer.currentSpan();
+      if (tag) span.tag("customer.id", "1234");
     }
   }
 


### PR DESCRIPTION
@lambcode noticed that calling `Tracer.currentSpan()` without using the
result can lead to orphaned spans. The simplest way to prevent this is
to defer overhead until data is added with the result.

Fixes #920

Added benchmarks..

before

```
TracerBenchmarks.currentSpan:currentSpan·p0.999                          sample             8.560             us/op
TracerBenchmarks.currentSpan:·gc.alloc.rate.norm                         sample      15    88.012 ±   0.005    B/op
TracerBenchmarks.currentSpan_tag:currentSpan_tag·p0.999                  sample            20.256             us/op
TracerBenchmarks.currentSpan_tag:·gc.alloc.rate.norm                     sample      15    88.065 ±   0.004    B/op
TracerBenchmarks.currentSpan_unsampled:currentSpan_unsampled·p0.999      sample             4.995             us/op
TracerBenchmarks.currentSpan_unsampled:·gc.alloc.rate.norm               sample      15    24.005 ±   0.001    B/op
```

after

```
TracerBenchmarks.currentSpan:currentSpan·p0.999                          sample              7.974             us/op
TracerBenchmarks.currentSpan:·gc.alloc.rate.norm                         sample      15     24.015 ±   0.008    B/op
TracerBenchmarks.currentSpan_tag:currentSpan_tag·p0.999                  sample             10.192             us/op
TracerBenchmarks.currentSpan_tag:·gc.alloc.rate.norm                     sample      15     72.050 ±  12.511    B/op
TracerBenchmarks.currentSpan_unsampled:currentSpan_unsampled·p0.999      sample              4.198             us/op
TracerBenchmarks.currentSpan_unsampled:·gc.alloc.rate.norm               sample      15     24.009 ±   0.007    B/op
```