### PR TITLE
Fixes assertion by making equals the same between lazy and real span

### DIFF
--- a/brave/src/main/java/brave/LazySpan.java
+++ b/brave/src/main/java/brave/LazySpan.java
@@ -16,6 +16,8 @@ package brave;
 import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
 
+import static brave.RealSpan.isEqualToRealOrLazySpan;
+
 /**
  * This defers creation of a span until first public method call.
  *
@@ -112,12 +114,7 @@ final class LazySpan extends Span {
    */
   @Override public boolean equals(Object o) {
     if (o == this) return true;
-    if (o instanceof LazySpan) {
-      return context.equals(((LazySpan) o).context);
-    } else if (o instanceof RealSpan) {
-      return context.equals(((RealSpan) o).context);
-    }
-    return false;
+    return isEqualToRealOrLazySpan(context, o);
   }
 
   /**

--- a/brave/src/main/java/brave/RealSpan.java
+++ b/brave/src/main/java/brave/RealSpan.java
@@ -28,10 +28,10 @@ final class RealSpan extends Span {
   final FinishedSpanHandler finishedSpanHandler;
 
   RealSpan(TraceContext context,
-      PendingSpans pendingSpans,
-      MutableSpan state,
-      Clock clock,
-      FinishedSpanHandler finishedSpanHandler
+    PendingSpans pendingSpans,
+    MutableSpan state,
+    Clock clock,
+    FinishedSpanHandler finishedSpanHandler
   ) {
     this.context = context;
     this.pendingSpans = pendingSpans;
@@ -164,10 +164,22 @@ final class RealSpan extends Span {
     return "RealSpan(" + context + ")";
   }
 
+  /**
+   * This also matches equals against a lazy span. The rationale is least surprise to the user, as
+   * code should not act differently given an instance of lazy or {@link RealSpan}.
+   */
   @Override public boolean equals(Object o) {
     if (o == this) return true;
-    if (!(o instanceof RealSpan)) return false;
-    return context.equals(((RealSpan) o).context);
+    return isEqualToRealOrLazySpan(context, o);
+  }
+
+  static boolean isEqualToRealOrLazySpan(TraceContext context, Object o) {
+    if (o instanceof LazySpan) {
+      return context.equals(((LazySpan) o).context);
+    } else if (o instanceof RealSpan) {
+      return context.equals(((RealSpan) o).context);
+    }
+    return false;
   }
 
   @Override public int hashCode() {

--- a/brave/src/test/java/brave/LazySpanTest.java
+++ b/brave/src/test/java/brave/LazySpanTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave;
+
+import brave.propagation.CurrentTraceContext.Scope;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LazySpanTest {
+  List<zipkin2.Span> spans = new ArrayList();
+  Tracing tracing = Tracing.newBuilder()
+    .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+    .spanReporter(spans::add)
+    .build();
+
+  TraceContext context = TraceContext.newBuilder().traceId(1L).spanId(1L).sampled(true).build();
+  TraceContext context2 = TraceContext.newBuilder().traceId(1L).spanId(2L).sampled(true).build();
+
+  @After public void close() {
+    tracing.close();
+  }
+
+  @Test public void equals_sameContext() {
+    Span current1, current2;
+    try (Scope ws = tracing.currentTraceContext().newScope(context)) {
+      current1 = tracing.tracer().currentSpan();
+      current2 = tracing.tracer().currentSpan();
+    }
+
+    assertThat(current1)
+      .isInstanceOf(LazySpan.class)
+      .isNotSameAs(current2)
+      .isEqualTo(current2);
+  }
+
+  @Test public void equals_notSameContext() {
+    Span current1, current2;
+    try (Scope ws = tracing.currentTraceContext().newScope(context)) {
+      current1 = tracing.tracer().currentSpan();
+    }
+    try (Scope ws = tracing.currentTraceContext().newScope(context2)) {
+      current2 = tracing.tracer().currentSpan();
+    }
+
+    assertThat(current1).isNotEqualTo(current2);
+  }
+
+  @Test public void equals_realSpan_sameContext() {
+    Span current;
+    try (Scope ws = tracing.currentTraceContext().newScope(context)) {
+      current = tracing.tracer().currentSpan();
+    }
+
+    assertThat(current).isEqualTo(tracing.tracer().toSpan(context));
+  }
+
+  @Test public void equals_realSpan_notSameContext() {
+    Span current;
+    try (Scope ws = tracing.currentTraceContext().newScope(context)) {
+      current = tracing.tracer().currentSpan();
+    }
+
+    assertThat(current).isNotEqualTo(tracing.tracer().toSpan(context2));
+  }
+}

--- a/brave/src/test/java/brave/propagation/ThreadLocalSpanTest.java
+++ b/brave/src/test/java/brave/propagation/ThreadLocalSpanTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package brave.propagation;
+
+import brave.Tracing;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThreadLocalSpanTest {
+
+  List<Span> spans = new ArrayList<>();
+  Tracing tracing = Tracing.newBuilder()
+    .currentTraceContext(ThreadLocalCurrentTraceContext.create())
+    .spanReporter(spans::add)
+    .build();
+
+  ThreadLocalSpan threadLocalSpan = ThreadLocalSpan.create(tracing.tracer());
+
+  @After public void close() {
+    tracing.close();
+  }
+
+  @Test public void next() {
+    assertThat(threadLocalSpan.next())
+      .isEqualTo(threadLocalSpan.remove());
+  }
+
+  @Test public void next_extracted() {
+    assertThat(threadLocalSpan.next(TraceContextOrSamplingFlags.DEBUG))
+      .isEqualTo(threadLocalSpan.remove());
+  }
+}


### PR DESCRIPTION
We had an assertion in `ThreadLocalSpan` which broke because our equals
comparison was one way. This fixes it.